### PR TITLE
Refactor API routes to use shared query parsing utilities

### DIFF
--- a/src/app/api/apsides/route.ts
+++ b/src/app/api/apsides/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/eclipses/route.ts
+++ b/src/app/api/eclipses/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/elongations/route.ts
+++ b/src/app/api/elongations/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/galactic/route.ts
+++ b/src/app/api/galactic/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/phases/route.ts
+++ b/src/app/api/phases/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/positions/route.ts
+++ b/src/app/api/positions/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/riseset/route.ts
+++ b/src/app/api/riseset/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
@@ -15,7 +8,7 @@ export async function GET(req: NextRequest) {
   const lon = num(url.searchParams.get("lon"), -38.5434);
   const tz  = str(url.searchParams.get("tz"), "America/Fortaleza");
   const when = str(url.searchParams.get("when"), new Date().toISOString());
-  const bodies = str(url.search_params.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
+  const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
   const data = await API.getRiseSet({ latitude: lat, longitude: lon, timezone: tz }, when, bodies as any);
   return Response.json({ ok: true, data });
 }

--- a/src/app/api/seasons/route.ts
+++ b/src/app/api/seasons/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/app/api/transits/route.ts
+++ b/src/app/api/transits/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,8 @@
+export function num(value: string | null, d: number) {
+  const n = value ? Number(value) : NaN;
+  return Number.isFinite(n) ? n : d;
+}
+
+export function str(value: string | null, d = "") {
+  return value ?? d;
+}


### PR DESCRIPTION
## Summary
- add shared `num` and `str` helpers for parsing query params
- refactor all API routes to use shared helpers
- fix riseset endpoint to read `bodies` param correctly

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build` *(compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a204372df48327aefc486ffbacc2f7