### PR TITLE
Rename app to Lyra Orrery and document Next.js setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 
-# Astro App (Next.js + Tailwind + astronomy.ts)
+# Lyra Orrery (Next.js + Tailwind + shadcn/ui + astronomy.ts)
 
-Este repositório usa `src/lib/astronomy.ts` como **fonte de verdade**.
+Aplicação Next.js que usa `src/lib/astronomy.ts` como **fonte de verdade** para dados astronômicos.
 
-## Rodar
+## Rodar localmente
+Requisitos: Node.js 18+ e npm.
+
 ```bash
 npm install
 npm run dev
+```
+Acesse <http://localhost:3000> para ver a interface. O botão "Gerar dados reais" utiliza componentes do shadcn/ui e chama o arquivo `astronomy.ts` via rotas API.
+
+## Verificar API
+As rotas REST estão em `/app/api/*`. Exemplo para posições:
+
+```bash
+curl "http://localhost:3000/api/positions?lat=-3.7&lon=-38.5"
 ```
 
 ## Build
@@ -20,16 +30,13 @@ npm start
 npm test
 ```
 
-## Endpoints REST
-Veja `/app/api/*` (positions, riseset, phases, seasons, elongations, eclipses, apsides, transits, galactic).
-
 ## Publicar no GitHub (sem Git instalado)
 - Faça download deste `.tar.gz` ou `.zip`.
 - Descompacte localmente.
-- **Abra um repositório no GitHub** (novo, vazio) e copie a URL (ex.: `git@github.com:SEU_USER/astro-app.git`).
+- **Abra um repositório no GitHub** (novo, vazio) e copie a URL (ex.: `git@github.com:SEU_USER/lyra-orrery.git`).
 
 Se tiver Git instalado, use o script:
 
 ```bash
-bash init-git-and-push.sh git@github.com:SEU_USER/astro-app.git
+bash init-git-and-push.sh git@github.com:SEU_USER/lyra-orrery.git
 ```

--- a/init-git-and-push.sh
+++ b/init-git-and-push.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REMOTE_URL="${1:-}"
 if [[ -z "$REMOTE_URL" ]]; then
   echo "Uso: bash init-git-and-push.sh <remote-url>"
-  echo "Ex.:  bash init-git-and-push.sh git@github.com:SEU_USER/astro-app.git"
+  echo "Ex.:  bash init-git-and-push.sh git@github.com:SEU_USER/lyra-orrery.git"
   exit 1
 fi
 
@@ -15,7 +15,7 @@ fi
 
 git init -b main
 git add .
-git commit -m "feat: initial commit (astro-app)"
+git commit -m "feat: initial commit (lyra-orrery)"
 git remote add origin "$REMOTE_URL"
 git push -u origin main
 echo "[OK] Repositório criado e push enviado para $REMOTE_URL"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "astro-app",
+  "name": "lyra-orrery",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "astro-app",
+      "name": "lyra-orrery",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.441.0",
@@ -689,6 +690,39 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astro-app",
+  "name": "lyra-orrery",
   "private": true,
   "version": "0.1.0",
   "scripts": {
@@ -17,7 +17,8 @@
     "react-dom": "18.2.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "@radix-ui/react-slot": "^1.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/src/app/api/apsides/route.ts
+++ b/src/app/api/apsides/route.ts
@@ -1,19 +1,16 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const body = str(url.searchParams.get("body"), "Moon");
-  const start = str(url.searchParams.get("start"), new Date().toISOString());
-  const count = num(url.searchParams.get("count"), 2);
-  const data = await API.getApsides(body, start, count);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const body = str(url.searchParams.get("body"), "Moon");
+    const start = str(url.searchParams.get("start"), new Date().toISOString());
+    const count = num(url.searchParams.get("count"), 2);
+    const data = await API.getApsides(body, start, count);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/eclipses/route.ts
+++ b/src/app/api/eclipses/route.ts
@@ -1,21 +1,18 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const lat = num(url.searchParams.get("lat"), -3.71722);
-  const lon = num(url.searchParams.get("lon"), -38.5434);
-  const tz  = str(url.searchParams.get("tz"), "America/Fortaleza");
-  const start = str(url.searchParams.get("start"), new Date().toISOString());
-  const scope = str(url.searchParams.get("scope"), "lunar") as "solar-global"|"solar-local"|"lunar";
-  const data = await API.getEclipses({ latitude: lat, longitude: lon, timezone: tz }, start, scope);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const lat = num(url.searchParams.get("lat"), -3.71722);
+    const lon = num(url.searchParams.get("lon"), -38.5434);
+    const tz = str(url.searchParams.get("tz"), "America/Fortaleza");
+    const start = str(url.searchParams.get("start"), new Date().toISOString());
+    const scope = str(url.searchParams.get("scope"), "lunar") as "solar-global" | "solar-local" | "lunar";
+    const data = await API.getEclipses({ latitude: lat, longitude: lon, timezone: tz }, start, scope);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/elongations/route.ts
+++ b/src/app/api/elongations/route.ts
@@ -1,19 +1,16 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const body = (str(url.searchParams.get("body"), "Mercury") as "Mercury"|"Venus");
-  const start = str(url.searchParams.get("start"), new Date().toISOString());
-  const count = num(url.searchParams.get("count"), 2);
-  const data = await API.getElongations(body, start, count);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const body = str(url.searchParams.get("body"), "Mercury") as "Mercury" | "Venus";
+    const start = str(url.searchParams.get("start"), new Date().toISOString());
+    const count = num(url.searchParams.get("count"), 2);
+    const data = await API.getElongations(body, start, count);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/galactic/route.ts
+++ b/src/app/api/galactic/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const when = str(url.searchParams.get("when"), new Date().toISOString());
-  const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
-  const data = await API.getGalacticCoords(when, bodies as any);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const when = str(url.searchParams.get("when"), new Date().toISOString());
+    const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
+    const data = await API.getGalacticCoords(when, bodies as any);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/phases/route.ts
+++ b/src/app/api/phases/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const month = num(url.searchParams.get("month"), (new Date().getMonth()+1));
-  const year  = num(url.searchParams.get("year"), new Date().getFullYear());
-  const data = await API.getLunarPhases(month, year);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const month = num(url.searchParams.get("month"), new Date().getMonth() + 1);
+    const year = num(url.searchParams.get("year"), new Date().getFullYear());
+    const data = await API.getLunarPhases(month, year);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/positions/route.ts
+++ b/src/app/api/positions/route.ts
@@ -1,21 +1,18 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const lat = num(url.searchParams.get("lat"), -3.71722);
-  const lon = num(url.searchParams.get("lon"), -38.5434);
-  const frame = str(url.searchParams.get("frame"), "geocentric") as API.Frame;
-  const when = str(url.searchParams.get("when"), new Date().toISOString());
-  const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
-  const data = await API.getPositions({ latitude: lat, longitude: lon }, frame, when, bodies as any);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const lat = num(url.searchParams.get("lat"), -3.71722);
+    const lon = num(url.searchParams.get("lon"), -38.5434);
+    const frame = str(url.searchParams.get("frame"), "geocentric") as API.Frame;
+    const when = str(url.searchParams.get("when"), new Date().toISOString());
+    const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
+    const data = await API.getPositions({ latitude: lat, longitude: lon }, frame, when, bodies as any);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/riseset/route.ts
+++ b/src/app/api/riseset/route.ts
@@ -1,21 +1,18 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const lat = num(url.searchParams.get("lat"), -3.71722);
-  const lon = num(url.searchParams.get("lon"), -38.5434);
-  const tz  = str(url.searchParams.get("tz"), "America/Fortaleza");
-  const when = str(url.searchParams.get("when"), new Date().toISOString());
+  try {
+    const url = new URL(req.url);
+    const lat = num(url.searchParams.get("lat"), -3.71722);
+    const lon = num(url.searchParams.get("lon"), -38.5434);
+    const tz = str(url.searchParams.get("tz"), "America/Fortaleza");
+    const when = str(url.searchParams.get("when"), new Date().toISOString());
     const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
-  const data = await API.getRiseSet({ latitude: lat, longitude: lon, timezone: tz }, when, bodies as any);
-  return Response.json({ ok: true, data });
+    const data = await API.getRiseSet({ latitude: lat, longitude: lon, timezone: tz }, when, bodies as any);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/seasons/route.ts
+++ b/src/app/api/seasons/route.ts
@@ -1,17 +1,14 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { num, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const year  = num(url.searchParams.get("year"), new Date().getFullYear());
-  const data = await API.getSeasons(year);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const year = num(url.searchParams.get("year"), new Date().getFullYear());
+    const data = await API.getSeasons(year);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/api/transits/route.ts
+++ b/src/app/api/transits/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest } from "next/server";
-  import * as API from "@/lib/astro-api";
-
-  function num(v: string | null, d: number) {
-    const n = v ? Number(v) : NaN;
-    return Number.isFinite(n) ? n : d;
-  }
-  function str(v: string | null, d = "") {
-    return v ?? d;
-  }
+import * as API from "@/lib/astro-api";
+import { str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const body = (str(url.searchParams.get("body"), "Mercury") as "Mercury"|"Venus");
-  const start = str(url.searchParams.get("start"), new Date().toISOString());
-  const data = await API.getTransits(body, start);
-  return Response.json({ ok: true, data });
+  try {
+    const url = new URL(req.url);
+    const body = str(url.searchParams.get("body"), "Mercury") as "Mercury" | "Venus";
+    const start = str(url.searchParams.get("start"), new Date().toISOString());
+    const data = await API.getTransits(body, start);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,9 @@
 import "@/app/globals.css";
-export const metadata = { title: "Astro App", description: "Astronomy data via astronomy.ts" };
-export default function RootLayout({ children }: { children: React.ReactNode }) { return (<html lang="pt-br"><body>{children}</body></html>); }
+export const metadata = { title: "Lyra Orrery", description: "Astronomy data via astronomy.ts" };
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="pt-br">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import * as API from "@/lib/astro-api";
 import { clampLatLon, fmtDeg, raDegToHms, formatMaybeDate } from "@/lib/format";
+import { Button } from "@/components/ui/button";
 
 type Frame = API.Frame;
 
@@ -150,7 +151,7 @@ export default function Page() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-zinc-100 to-white text-zinc-900">
       <header className="mx-auto max-w-6xl px-4 py-6">
-        <h1 className="text-lg font-semibold">Astro App — Dados Reais via <code>astronomy.ts</code></h1>
+        <h1 className="text-lg font-semibold">Lyra Orrery — Dados Reais via <code>astronomy.ts</code></h1>
         <p className="text-xs text-zinc-500 mt-1">Mostrando signo + grau no signo, constelação IAU e RA/Dec em graus.</p>
       </header>
 
@@ -174,7 +175,7 @@ export default function Page() {
             <Field label="Data/hora (local)"><input type="datetime-local" className="h-10 rounded-lg border border-zinc-300 bg-white px-3 text-sm" value={when} onChange={(e)=>setWhen(e.target.value)} /></Field>
           </div>
           <div className="mt-4 flex items-center gap-4">
-            <button onClick={handleGenerate} className="h-10 px-4 rounded-lg bg-zinc-900 text-white text-sm hover:bg-zinc-800 hover:shadow-md transition">{loading ? <span className="animate-pulse">Calculando…</span> : "Gerar dados reais"}</button>
+            <Button onClick={handleGenerate} className="h-10 px-4">{loading ? <span className="animate-pulse">Calculando…</span> : "Gerar dados reais"}</Button>
             {err && <span className="text-xs text-red-600">{err}</span>}
           </div>
         </Section>
@@ -213,7 +214,7 @@ export default function Page() {
         </Section>
 
         <footer className="text-xs text-zinc-400 mt-4">
-          <p>© {new Date().getFullYear()} Astro App — Powered by <code>astronomy.ts</code>. Design: Tailwind (zinc).</p>
+          <p>© {new Date().getFullYear()} Lyra Orrery — Powered by <code>astronomy.ts</code>. Design: Tailwind, shadcn/ui.</p>
         </footer>
       </main>
     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-zinc-900 text-white hover:bg-zinc-800",
+        destructive: "bg-red-500 text-white hover:bg-red-600",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,13 @@
+export function jsonError(err: unknown, status = 500) {
+  const message = err instanceof Error ? err.message : String(err)
+  return Response.json({ ok: false, error: message }, { status })
+}
+
+export function num(v: string | null, d: number) {
+  const n = v ? Number(v) : NaN
+  return Number.isFinite(n) ? n : d
+}
+
+export function str(v: string | null, d = "") {
+  return v ?? d
+}


### PR DESCRIPTION
## Summary
- rename project to **Lyra Orrery** and add shadcn/ui button component
- centralize API helpers and unify error handling across routes
- expand README with local run instructions and API examples

## Testing
- `npm install`
- `npm test` *(fails: No test files found)*
- `npm run build` *(warnings: Attempted import error: 'Time' and 'Direction' not exported)*

------
https://chatgpt.com/codex/tasks/task_e_68a20a95b09c8327943cee7ce8bf540a