### PR TITLE
fix rise/set table values missing

### DIFF
--- a/src/lib/astro-api.ts
+++ b/src/lib/astro-api.ts
@@ -88,8 +88,8 @@ export async function getRiseSet(observer: {latitude:number; longitude:number; t
     try {
       let rise = null, set = null, transit = null;
       if (SearchRiseSet) {
-        const r = SearchRiseSet(name, ob, Direction.Rise, time);
-        const s = SearchRiseSet(name, ob, Direction.Set, time);
+        const r = SearchRiseSet(name, ob, Direction.Rise, time, 1);
+        const s = SearchRiseSet(name, ob, Direction.Set, time, 1);
         // @ts-ignore
         rise = r?.time?.toString?.() || (r?.date ?? null);
         // @ts-ignore


### PR DESCRIPTION
## Summary
- include a 1-day search window when computing rise/set events

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2136b9e3c8327a1ee31a32733aab8