### PR TITLE
refactor: centralize query parsing for API routes

### DIFF
--- a/src/app/api/eclipses/route.ts
+++ b/src/app/api/eclipses/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest } from "next/server";
 import * as API from "@/lib/astro-api";
-import { num, str, jsonError } from "@/lib/api-utils";
+import { parseQuery, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   try {
-    const url = new URL(req.url);
-    const lat = num(url.searchParams.get("lat"), -3.71722);
-    const lon = num(url.searchParams.get("lon"), -38.5434);
-    const tz = str(url.searchParams.get("tz"), "America/Fortaleza");
+    const { url, lat, lon, tz } = parseQuery(req);
     const start = str(url.searchParams.get("start"), new Date().toISOString());
     const scope = str(url.searchParams.get("scope"), "lunar") as "solar-global" | "solar-local" | "lunar";
     const data = await API.getEclipses({ latitude: lat, longitude: lon, timezone: tz }, start, scope);

--- a/src/app/api/positions/route.ts
+++ b/src/app/api/positions/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest } from "next/server";
 import * as API from "@/lib/astro-api";
-import { num, str, jsonError } from "@/lib/api-utils";
+import { parseQuery, str, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   try {
-    const url = new URL(req.url);
-    const lat = num(url.searchParams.get("lat"), -3.71722);
-    const lon = num(url.searchParams.get("lon"), -38.5434);
+    const { url, lat, lon, when, bodies } = parseQuery(req);
     const frame = str(url.searchParams.get("frame"), "geocentric") as API.Frame;
-    const when = str(url.searchParams.get("when"), new Date().toISOString());
-    const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
     const data = await API.getPositions({ latitude: lat, longitude: lon }, frame, when, bodies as any);
     return Response.json({ ok: true, data });
   } catch (err) {

--- a/src/app/api/riseset/route.ts
+++ b/src/app/api/riseset/route.ts
@@ -1,15 +1,10 @@
 import { NextRequest } from "next/server";
 import * as API from "@/lib/astro-api";
-import { num, str, jsonError } from "@/lib/api-utils";
+import { parseQuery, jsonError } from "@/lib/api-utils";
 
 export async function GET(req: NextRequest) {
   try {
-    const url = new URL(req.url);
-    const lat = num(url.searchParams.get("lat"), -3.71722);
-    const lon = num(url.searchParams.get("lon"), -38.5434);
-    const tz = str(url.searchParams.get("tz"), "America/Fortaleza");
-    const when = str(url.searchParams.get("when"), new Date().toISOString());
-    const bodies = str(url.searchParams.get("bodies"), "").split(",").filter(Boolean) as any[] || undefined;
+    const { lat, lon, tz, when, bodies } = parseQuery(req);
     const data = await API.getRiseSet({ latitude: lat, longitude: lon, timezone: tz }, when, bodies as any);
     return Response.json({ ok: true, data });
   } catch (err) {

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,13 +1,47 @@
+import { NextRequest } from "next/server";
+import { ALL_BODIES, BodyName } from "@/lib/astro-api";
+
 export function jsonError(err: unknown, status = 500) {
-  const message = err instanceof Error ? err.message : String(err)
-  return Response.json({ ok: false, error: message }, { status })
+  const message = err instanceof Error ? err.message : String(err);
+  return Response.json({ ok: false, error: message }, { status });
 }
 
 export function num(v: string | null, d: number) {
-  const n = v ? Number(v) : NaN
-  return Number.isFinite(n) ? n : d
+  const n = v ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : d;
 }
 
 export function str(v: string | null, d = "") {
-  return v ?? d
+  return v ?? d;
+}
+
+export function parseQuery(req: NextRequest) {
+  const url = new URL(req.url);
+
+  const lat = num(url.searchParams.get("lat"), -3.71722);
+  if (lat < -90 || lat > 90) throw new Error("invalid latitude");
+
+  const lon = num(url.searchParams.get("lon"), -38.5434);
+  if (lon < -180 || lon > 180) throw new Error("invalid longitude");
+
+  const tz = str(url.searchParams.get("tz"), "America/Fortaleza");
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: tz });
+  } catch {
+    throw new Error("invalid timezone");
+  }
+
+  const whenStr = str(url.searchParams.get("when"), new Date().toISOString());
+  const whenDate = new Date(whenStr);
+  if (isNaN(whenDate.getTime())) throw new Error("invalid date");
+
+  const bodiesParam = str(url.searchParams.get("bodies"), "");
+  let bodies: BodyName[] | undefined = undefined;
+  if (bodiesParam) {
+    const list = bodiesParam.split(",").map((s) => s.trim()).filter(Boolean);
+    const valid = list.filter((b) => ALL_BODIES.includes(b as any)) as BodyName[];
+    if (valid.length) bodies = valid;
+  }
+
+  return { url, lat, lon, tz, when: whenDate.toISOString(), bodies };
 }


### PR DESCRIPTION
## Summary
- add `parseQuery` helper to consolidate default values and validation for query parameters
- update `positions`, `riseset`, and `eclipses` API routes to use the shared helper

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a21f87b3b88327864058b87a3ec6da