### PR TITLE
feat: expose additional astronomy search utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,48 @@
-
 # Lyra Orrery (Next.js + Tailwind + shadcn/ui + astronomy.ts)
 
 Next.js application that uses `src/lib/astronomy.ts` as the **source of truth** for astronomical data.
 
 ## Run locally
+
 Requirements: Node.js 18+ and npm.
 
 ```bash
 npm install
 npm run dev
 ```
+
 Visit <http://localhost:3000> to view the interface. The "Generate real data" button uses shadcn/ui components and calls the `astronomy.ts` file through API routes.
 
 ## Verify the API
+
 REST routes are under `/app/api/*`. Example for positions:
 
 ```bash
 curl "http://localhost:3000/api/positions?lat=-3.7&lon=-38.5"
 ```
 
+Search helpers include endpoints like:
+
+```bash
+curl "http://localhost:3000/api/sunlongitude?targetLon=0&start=2024-03-19"
+curl "http://localhost:3000/api/moonphase?targetLon=90&start=2024-03-19"
+```
+
 ## Build
+
 ```bash
 npm run build
 npm start
 ```
 
 ## Tests
+
 ```bash
 npm test
 ```
 
 ## Publish to GitHub (without Git installed)
+
 - Download this `.tar.gz` or `.zip`.
 - Extract it locally.
 - **Create an empty repository on GitHub** and copy its URL (e.g., `git@github.com:YOUR_USER/lyra-orrery.git`).

--- a/src/app/api/moonphase/route.ts
+++ b/src/app/api/moonphase/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import * as API from '@/lib/astro-api';
+import { num, str, jsonError } from '@/lib/api-utils';
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const targetLon = num(url.searchParams.get('targetLon'), 0);
+    const start = str(url.searchParams.get('start'), new Date().toISOString());
+    const limitDays = num(url.searchParams.get('limitDays'), 40);
+    const data = await API.getMoonPhase(targetLon, start, limitDays);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
+}

--- a/src/app/api/sunlongitude/route.ts
+++ b/src/app/api/sunlongitude/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import * as API from '@/lib/astro-api';
+import { num, str, jsonError } from '@/lib/api-utils';
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const targetLon = num(url.searchParams.get('targetLon'), 0);
+    const start = str(url.searchParams.get('start'), new Date().toISOString());
+    const limitDays = num(url.searchParams.get('limitDays'), 365);
+    const data = await API.getSunLongitude(targetLon, start, limitDays);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -354,8 +354,13 @@ export default function Page() {
 
       const ecL = await API.getEclipses(observer, date, 'lunar');
       const ecS = await API.getEclipses(observer, date, 'solar-local');
+      const ecG = await API.getEclipses(observer, date, 'solar-global');
       setEclipses(
-        [...(ecL?.events || []), ...(ecS?.events || [])].map((e: any) => ({
+        [
+          ...(ecL?.events || []),
+          ...(ecS?.events || []),
+          ...(ecG?.events || []),
+        ].map((e: any) => ({
           ...e,
           time: formatMaybeDate(e.time, tz),
           magnitudeFmt:

--- a/src/lib/astro-api.ts
+++ b/src/lib/astro-api.ts
@@ -211,6 +211,30 @@ export async function getLunarPhases(month: number, year: number) {
   return { month, year, phases: out };
 }
 
+export async function getMoonPhase(
+  targetLon: number,
+  startFrom: Date | string,
+  limitDays = 40
+) {
+  const date = typeof startFrom === 'string' ? new Date(startFrom) : startFrom;
+  const time = makeTime(date);
+  try {
+    // @ts-ignore
+    const SearchMoonPhase = (Astro as any).SearchMoonPhase;
+    const t = SearchMoonPhase
+      ? SearchMoonPhase(targetLon, time, limitDays)
+      : null;
+    return {
+      targetLon,
+      startFrom: date.toISOString(),
+      limitDays,
+      time: t?.toString?.() || (t ? String(t) : null),
+    };
+  } catch {
+    return { targetLon, startFrom: date.toISOString(), limitDays, time: null };
+  }
+}
+
 export async function getSeasons(year: number) {
   try {
     // @ts-ignore
@@ -241,6 +265,30 @@ export async function getSeasons(year: number) {
     return { year, entries };
   } catch {
     return { year, entries: [] };
+  }
+}
+
+export async function getSunLongitude(
+  targetLon: number,
+  startFrom: Date | string,
+  limitDays = 365
+) {
+  const date = typeof startFrom === 'string' ? new Date(startFrom) : startFrom;
+  const time = makeTime(date);
+  try {
+    // @ts-ignore
+    const SearchSunLongitude = (Astro as any).SearchSunLongitude;
+    const t = SearchSunLongitude
+      ? SearchSunLongitude(targetLon, time, limitDays)
+      : null;
+    return {
+      targetLon,
+      startFrom: date.toISOString(),
+      limitDays,
+      time: t?.toString?.() || (t ? String(t) : null),
+    };
+  } catch {
+    return { targetLon, startFrom: date.toISOString(), limitDays, time: null };
   }
 }
 
@@ -291,6 +339,18 @@ export async function getEclipses(
           time: e.peak?.toString?.() || String(e.peak),
           magnitude: e?.kind || null,
           path: null,
+        });
+    }
+    // @ts-ignore
+    if (scope === 'solar-global' && (Astro as any).SearchGlobalSolarEclipse) {
+      // @ts-ignore
+      const e = (Astro as any).SearchGlobalSolarEclipse(time);
+      if (e)
+        events.push({
+          type: e?.kind || 'solar',
+          time: e.peak?.toString?.() || String(e.peak),
+          magnitude: e?.obscuration ?? null,
+          path: 'global',
         });
     }
     // @ts-ignore


### PR DESCRIPTION
## Summary
- wrap SearchMoonPhase and SearchSunLongitude in API
- handle global solar eclipses and show them in the UI
- document new `/api/moonphase` and `/api/sunlongitude` routes

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a22c3a945083279664faeb2c6b4248