### PR TITLE
feat: add body data API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.next

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Search helpers include endpoints like:
 ```bash
 curl "http://localhost:3000/api/sunlongitude?targetLon=0&start=2024-03-19"
 curl "http://localhost:3000/api/moonphase?targetLon=90&start=2024-03-19"
+curl "http://localhost:3000/api/bodydata?bodies=Earth,Mars"
 ```
 
 ## Build

--- a/src/app/api/bodydata/route.ts
+++ b/src/app/api/bodydata/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import * as API from '@/lib/astro-api';
+import { str, jsonError } from '@/lib/api-utils';
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const bodies = str(url.searchParams.get('bodies'), '')
+      .split(',')
+      .filter(Boolean) as API.BodyName[] | undefined;
+    const data = await API.getBodyData(bodies as any);
+    return Response.json({ ok: true, data });
+  } catch (err) {
+    return jsonError(err);
+  }
+}

--- a/src/lib/astro-api.ts
+++ b/src/lib/astro-api.ts
@@ -6,6 +6,7 @@ import {
   signGlyph,
   zodiacDeg,
 } from '@/lib/format';
+import { BODY_DATA } from '@/lib/planet-data';
 
 export type Frame = 'geocentric' | 'heliocentric';
 export const ALL_BODIES = [
@@ -449,6 +450,20 @@ export async function getGalacticCoords(
     }
   }
   return out;
+}
+
+export async function getBodyData(
+  bodies: readonly BodyName[] | BodyName[] = ALL_BODIES,
+) {
+  return bodies.map((name) => {
+    const d = BODY_DATA.find((b) => b.name === name);
+    return {
+      name,
+      gm: d?.gm ?? null,
+      equatorialRadiusKm: d?.equatorialRadiusKm ?? null,
+      polarRadiusKm: d?.polarRadiusKm ?? null,
+    };
+  });
 }
 
 export async function getAspectsRange(

--- a/src/lib/planet-data.ts
+++ b/src/lib/planet-data.ts
@@ -1,0 +1,80 @@
+export interface BodyData {
+  name: string;
+  gm: number; // gravitational parameter au^3/day^2
+  equatorialRadiusKm: number;
+  polarRadiusKm: number;
+}
+
+import {
+  JUPITER_EQUATORIAL_RADIUS_KM,
+  JUPITER_POLAR_RADIUS_KM,
+} from '@/lib/astronomy';
+
+export const BODY_DATA: BodyData[] = [
+  {
+    name: 'Mercury',
+    gm: 0.4912547451450812e-10,
+    equatorialRadiusKm: 2439.7,
+    polarRadiusKm: 2439.7,
+  },
+  {
+    name: 'Venus',
+    gm: 0.7243452486162703e-09,
+    equatorialRadiusKm: 6051.8,
+    polarRadiusKm: 6051.8,
+  },
+  {
+    name: 'Earth',
+    gm: 0.8887692390113509e-09,
+    equatorialRadiusKm: 6378.137,
+    polarRadiusKm: 6356.752,
+  },
+  {
+    name: 'Mars',
+    gm: 0.9549535105779258e-10,
+    equatorialRadiusKm: 3396.2,
+    polarRadiusKm: 3376.2,
+  },
+  {
+    name: 'Jupiter',
+    gm: 0.2825345909524226e-06,
+    equatorialRadiusKm: JUPITER_EQUATORIAL_RADIUS_KM,
+    polarRadiusKm: JUPITER_POLAR_RADIUS_KM,
+  },
+  {
+    name: 'Saturn',
+    gm: 0.8459715185680659e-07,
+    equatorialRadiusKm: 60268,
+    polarRadiusKm: 54364,
+  },
+  {
+    name: 'Uranus',
+    gm: 0.1292024916781969e-07,
+    equatorialRadiusKm: 25559,
+    polarRadiusKm: 24973,
+  },
+  {
+    name: 'Neptune',
+    gm: 0.1524358900784276e-07,
+    equatorialRadiusKm: 24764,
+    polarRadiusKm: 24341,
+  },
+  {
+    name: 'Pluto',
+    gm: 0.2188699765425970e-11,
+    equatorialRadiusKm: 1188.3,
+    polarRadiusKm: 1188.3,
+  },
+  {
+    name: 'Moon',
+    gm: 0.8887692390113509e-09 / 81.30056,
+    equatorialRadiusKm: 1738.1,
+    polarRadiusKm: 1736.0,
+  },
+  {
+    name: 'Sun',
+    gm: 0.2959122082855911e-03,
+    equatorialRadiusKm: 695700,
+    polarRadiusKm: 695700,
+  },
+];


### PR DESCRIPTION
## Summary
- add data table of gravitational parameters and radii for solar system bodies
- expose `getBodyData` wrapper and `/api/bodydata` route to retrieve constants
- document new endpoint and ignore Next.js build output

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23620df888327a96cdec6529834a6